### PR TITLE
Add requirements, fix Windows sound

### DIFF
--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,0 +1,2 @@
+Pillow
+PyInstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# Newer versions of PyQt6 break sound on Windows
+# See: https://stackoverflow.com/a/78582768
+PyQt6==6.6.1
+PyQt6-Qt6==6.6.1
+PyQt6-sip==13.6.0
+
+# Don't care about versions of these
+requests


### PR DESCRIPTION
Add requirements.txt files for both running and building the software.

As a byproduct of adding requirements.txt, fix sound on Windows by pinning the scoring software to an older version of PyQt. The 6.7.x series of releases have a regression that cause sound on Windows to not work without manually adding ffmpeg DLLs to the package installation.