### PR TITLE
Log match start time, auto-increment match number

### DIFF
--- a/Audience.py
+++ b/Audience.py
@@ -55,7 +55,7 @@ class AudienceWindow(QMainWindow):
         self.dlg = None
         self.parent = parent
         self.timerMode = False
-        self.timer = TimerWidget()
+        self.timer = TimerWidget(parent)
 
         try:
             super().__init__()
@@ -177,8 +177,10 @@ class AudienceWindow(QMainWindow):
 
 
 class TimerWidget(QWidget):
-    def __init__(self):
+    def __init__(self, main):
         super().__init__()
+
+        self.main = main
 
         self.remainingTime = INITIAL_TIME
         self.timerRunning = False
@@ -259,6 +261,7 @@ class TimerWidget(QWidget):
         else:
             self.timer.stop()
             self.showLogo()
+            self.main.timerComplete()
 
     def showLogo(self):
         self.timerLabel.setPixmap(self.logo)

--- a/Main.py
+++ b/Main.py
@@ -138,7 +138,7 @@ class MainWindow(QMainWindow):
             self.timerMode = QAction("Change Audience to Timer")
             self.timerMode.triggered.connect(self.changeMode)
             self.timerStart = QAction("Start Timer")
-            self.timerStart.triggered.connect(self.audienceDisplay.timer.startTimer)
+            self.timerStart.triggered.connect(self.startTimer)
             self.timerReset = QAction("Reset Timer")
             self.timerReset.triggered.connect(self.audienceDisplay.timer.resetTimer)
             self.rankingsTop = QAction("Scroll to Top of Rankings")
@@ -495,6 +495,13 @@ class MainWindow(QMainWindow):
         self.audienceDisplay.changeMode()
         self.timerMode.setText(f"Change Audience to {'Rankings' if self.audienceDisplay.timerMode else 'Timer'}")
         self.menuBar().update()
+
+    def startTimer(self):
+        Substrate.writeLogEntry("match_start", f"{self.matchNum.value()}")
+        self.audienceDisplay.timer.startTimer()
+
+    def timerComplete(self):
+        self.matchNum.setValue(self.matchNum.value() + 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For events using the scoring software timer, log when the match is started, and automatically increment the match number display when the match is complete.