### PR TITLE
Refine window startup process

### DIFF
--- a/Audience.py
+++ b/Audience.py
@@ -94,7 +94,6 @@ class AudienceWindow(QMainWindow):
             self.setCentralWidget(self.mainWidget)
             self.setStyleSheet(sheet)
 
-            self.show()
         except Exception as err:
             print(err)
 

--- a/Main.py
+++ b/Main.py
@@ -109,9 +109,7 @@ class MainWindow(QMainWindow):
             self.mainWidget = QWidget()
             self.mainLayout = QGridLayout()
 
-            # Activate audience display
             self.audienceDisplay = AudienceWindow(self)
-            self.audienceDisplay.show()
 
             self.menuBar().setNativeMenuBar(False)
 
@@ -221,6 +219,11 @@ class MainWindow(QMainWindow):
 
             self.rerank()
             self.show()
+
+            # Render audience window, then bring focus back to main scoring window
+            self.audienceDisplay.show()
+            self.raise_()
+            self.activateWindow()
 
             application.exec()
         except Exception as err:


### PR DESCRIPTION
Defer showing the audience window until after the scoring window has been shown; this puts the taskbar buttons in a more intuitive order. After the audience display has been shown, bring focus back to the scoring window.