### PR TITLE
Fix double quote within f-string

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -529,7 +529,7 @@ class MainWindow(QMainWindow):
 
     def changeMode(self):
         self.audienceDisplay.changeMode()
-        self.timerMode.setText(f"Show {'Rankings' if self.audienceDisplay.mode != "ranks" else 'Timer'}")
+        self.timerMode.setText(f"Show {'Rankings' if self.audienceDisplay.mode != 'ranks' else 'Timer'}")
         self.timerCtl.setDisabled(False if self.audienceDisplay.mode != "ranks" else True)
         self.menuBar().update()
 


### PR DESCRIPTION
Restore compatibility with pre-3.12 Python by using a single quote instead of a double quote within an f-string.