### PR TITLE
Prevent foghorn from sounding after match end buzzer

### DIFF
--- a/Audience.py
+++ b/Audience.py
@@ -274,9 +274,8 @@ class TimerWidget(QWidget):
             if self.remainingTime == 0:
                 self.playSound("end")
         else:
+            self.timerRunning = False
             self.main.timerComplete()
-            # Reset timer after main callback to prevent a "flash" of the newly-reset timer
-            self.resetTimer()
 
     def playSound(self, sound: str):
         self.mediaPlayer.setSource(media[sound])


### PR DESCRIPTION
Commit 7d45cbf29f80f8b6064a703dedfea6077923cd16 introduced a regression that causes the foghorn (match abort sound) to trigger after the match complete buzzer. The root cause is that the timer is still considered "running" when resetTimer is called (both by timerComplete and redundantly in updateTimer).

Until the timer logic is moved into the main application (see #2), patch this by explicitly setting the timer running variable to False before doing anything that would reset the timer, and also remove the redundant resetTimer call.